### PR TITLE
Support multiple scoring methods of UnifiedMetric

### DIFF
--- a/mbrs/conftest.py
+++ b/mbrs/conftest.py
@@ -1,6 +1,7 @@
 import pytest
+import torch
 
-from mbrs.metrics import MetricCOMET, MetricCOMETQE
+from mbrs.metrics import MetricCOMET, MetricCOMETQE, MetricXCOMET
 
 
 @pytest.fixture(scope="session")
@@ -11,3 +12,11 @@ def metric_comet():
 @pytest.fixture(scope="session")
 def metric_cometqe():
     return MetricCOMETQE(MetricCOMETQE.Config())
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available on this machine."
+)
+@pytest.fixture(scope="session")
+def metric_xcomet():
+    return MetricXCOMET(MetricXCOMET.Config())

--- a/mbrs/decoders/rerank.py
+++ b/mbrs/decoders/rerank.py
@@ -27,7 +27,7 @@ class DecoderRerank(DecoderReferenceless):
             DecoderRerank.Output: The n-best hypotheses.
         """
         with timer.measure("rerank"):
-            scores = self.metric.scores(hypotheses, source)
+            scores = self.metric.scores(hypotheses, source=source)
         topk_scores, topk_indices = self.metric.topk(scores, k=nbest)
         return self.Output(
             idx=topk_indices,

--- a/mbrs/metrics/xcomet_test.py
+++ b/mbrs/metrics/xcomet_test.py
@@ -1,1 +1,72 @@
-# TODO(deguchi): Add unit tests for XCOMET
+import pytest
+import torch
+
+from .xcomet import MetricXCOMET
+
+SOURCE = "これはテストです"
+HYPOTHESES = [
+    "this is a test",
+    "another test",
+    "this is a fest",
+    "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
+]
+REFERENCES = [
+    "ref",
+    "this is a test",
+    "producţia de zahăr brut se exprimă în zahăr alb;",
+]
+SCORES = torch.Tensor(
+    [
+        [0.97671, 1.00000, 0.49054],
+        [0.94399, 0.99120, 0.43007],
+        [0.71786, 0.71210, 0.30775],
+        [0.21788, 0.22079, 0.61004],
+    ]
+)
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available on this machine."
+)
+class TestMetricXCOMET:
+    def test_score(self, metric_xcomet: MetricXCOMET):
+        for i, hyp in enumerate(HYPOTHESES):
+            for j, ref in enumerate(REFERENCES):
+                assert torch.isclose(
+                    SCORES[i, j],
+                    torch.tensor(metric_xcomet.score(hyp, ref, SOURCE)),
+                    atol=0.0005 / 100,
+                )
+
+    def test_scores(self, metric_xcomet: MetricXCOMET):
+        hyps = ["another test", "this is a test", "this is an test"]
+        refs = ["another test", "this is a fest", "this is a test"]
+        src = SOURCE
+
+        torch.testing.assert_close(
+            metric_xcomet.scores(hyps, refs, src).cpu().float(),
+            torch.FloatTensor([1.00000, 0.90545, 1.00000]),
+            atol=0.0005 / 100,
+            rtol=1e-6,
+        )
+        torch.testing.assert_close(
+            metric_xcomet.scores(hyps, source=src).cpu().float(),
+            torch.FloatTensor([0.99120, 0.99120, 0.99120]),
+            atol=0.0005 / 100,
+            rtol=1e-6,
+        )
+        torch.testing.assert_close(
+            metric_xcomet.scores(hyps, references=refs).cpu().float(),
+            torch.FloatTensor([1.00000, 0.77420, 1.00000]),
+            atol=0.0005 / 100,
+            rtol=1e-6,
+        )
+
+    def test_expected_scores(self, metric_xcomet: MetricXCOMET):
+        expected_scores = metric_xcomet.expected_scores(HYPOTHESES, REFERENCES, SOURCE)
+        torch.testing.assert_close(
+            expected_scores,
+            SCORES.mean(dim=1).to(metric_xcomet.device),
+            atol=0.0005 / 100,
+            rtol=1e-6,
+        )

--- a/mbrs/metrics/xcomet_test.py
+++ b/mbrs/metrics/xcomet_test.py
@@ -1,17 +1,1 @@
-import pytest
-import torch
-
-from .xcomet import to_device
-
-
-@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available on this machine.")
-def test_to_device():
-    device = torch.device("cuda:0")
-
-    for x in [1, 1.0, "a", True]:
-        assert to_device(x, device) == x
-
-    assert to_device(torch.ones(1), device).device == device
-    assert to_device({"a": torch.ones(1)}, device)["a"].device == device
-    assert to_device([torch.ones(1)], device)[0].device == device
-    assert to_device((torch.ones(1),), device)[0].device == device
+# TODO(deguchi): Add unit tests for XCOMET

--- a/mbrs/utils.py
+++ b/mbrs/utils.py
@@ -1,0 +1,21 @@
+from typing import Any
+
+import torch
+
+
+def to_device(sample: Any, device: torch.device):
+    def _to_device(x):
+        if torch.is_tensor(x):
+            return x.to(device=device, non_blocking=True)
+        elif isinstance(x, dict):
+            return {key: _to_device(value) for key, value in x.items()}
+        elif isinstance(x, list):
+            return [_to_device(x) for x in x]
+        elif isinstance(x, tuple):
+            return tuple(_to_device(x) for x in x)
+        elif isinstance(x, set):
+            return {_to_device(x) for x in x}
+        else:
+            return x
+
+    return _to_device(sample)

--- a/mbrs/utils_test.py
+++ b/mbrs/utils_test.py
@@ -1,0 +1,19 @@
+import pytest
+import torch
+
+from . import utils
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="CUDA is not available on this machine."
+)
+def test_to_device():
+    device = torch.device("cuda:0")
+
+    for x in [1, 1.0, "a", True]:
+        assert utils.to_device(x, device) == x
+
+    assert utils.to_device(torch.ones(1), device).device == device
+    assert utils.to_device({"a": torch.ones(1)}, device)["a"].device == device
+    assert utils.to_device([torch.ones(1)], device)[0].device == device
+    assert utils.to_device((torch.ones(1),), device)[0].device == device


### PR DESCRIPTION
This pull request is to support multiple scoring methods of `UnifiedMetric` models, e.g., XCOMET:
- src: (src, mt)
- ref: (mt, ref)
- src+ref: (src, mt, ref)