### PR TITLE
Add a scoring script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -62,7 +62,20 @@ This example regards the hypothesis set as the pseudo-reference set.
       --decoder mbr \
       --metric comet \
       --metric.model Unbabel/wmt22-comet-da \
-      --metric.batch_size 64 --metric.fp16
+      --metric.batch_size 64 --metric.fp16 true
+
+Finally, you can evaluate the score with :code:`mbrs-score`:
+
+.. code:: bash
+
+    mbrs-score \
+      hypotheses.txt \
+      --sources sources.txt \
+      --references hypotheses.txt \
+      --format json \
+      --metric bleurt \
+      --metric.batch_size 64 --metric.fp16 true
+
 
 Python API
 ----------

--- a/mbrs/cli/score.py
+++ b/mbrs/cli/score.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+
+import enum
+import json
+import logging
+import os
+import sys
+from argparse import Namespace
+from dataclasses import asdict, dataclass
+
+import simple_parsing
+from simple_parsing import ArgumentParser, choice, field, flag
+from simple_parsing.wrappers import dataclass_wrapper
+
+from mbrs import registry
+from mbrs.metrics import Metric, get_metric
+from mbrs.metrics.base import MetricReferenceless
+
+simple_parsing.parsing.logger.setLevel(logging.ERROR)
+dataclass_wrapper.logger.setLevel(logging.ERROR)
+
+logging.basicConfig(
+    format="%(asctime)s | %(levelname)s | %(name)s | %(message)s",
+    datefmt="%Y-%m-%d %H:%M:%S",
+    level=os.environ.get("LOGLEVEL", "INFO").upper(),
+    stream=sys.stdout,
+)
+logger = logging.getLogger(__name__)
+
+
+class Format(enum.Enum):
+    plain = "plain"
+    json = "json"
+
+
+@dataclass
+class CommonArguments:
+    """Common arguments."""
+
+    # Hypotheses file.
+    hypotheses: str = field(positional=True)
+    # Source file.
+    source: str | None = field(default=None, alias=["-s"])
+    # References file.
+    references: str | None = field(default=None, alias=["-r"])
+    # Output format.
+    format: Format = choice(Format, default=Format.json)
+    # Type of the metric.
+    metric: str = choice(*registry.get_registry("metric").keys(), default="bleu")
+    # No verbose information and report.
+    quiet: bool = flag(default=False)
+    # Number of digits for values of float point.
+    width: int = field(default=1, alias=["-w"])
+
+
+def parse_args() -> Namespace:
+    meta_parser = ArgumentParser(add_help=False)
+    meta_parser.add_arguments(CommonArguments, "common")
+    known_args, _ = meta_parser.parse_known_args()
+    metric_type = get_metric(known_args.common.metric)
+
+    parser = ArgumentParser(add_help=True)
+    parser.add_arguments(CommonArguments, "common")
+    parser.add_arguments(metric_type.Config, "metric", prefix="metric.")
+    return parser.parse_args()
+
+
+def main(args: Namespace) -> None:
+    with open(args.common.hypotheses, mode="r") as f:
+        hypotheses = f.readlines()
+    num_sents = len(hypotheses)
+
+    sources = None
+    if args.common.source is not None:
+        with open(args.common.source, mode="r") as f:
+            sources = f.readlines()
+        assert num_sents == len(sources)
+
+    references = None
+    if args.common.references is not None:
+        with open(args.common.references, mode="r") as f:
+            references = f.readlines()
+        assert num_sents == len(references)
+
+    metric_type = get_metric(args.common.metric)
+    metric: Metric = metric_type(args.metric)
+
+    if isinstance(metric, MetricReferenceless):
+        assert sources is not None
+        corpus_score = metric.corpus_score(hypotheses, sources=sources)
+    else:
+        assert references is not None
+        corpus_score = metric.corpus_score(hypotheses, references, sources)
+
+    score = {
+        "name": args.common.metric,
+        "score": float(f"{corpus_score:.{args.common.width}f}"),
+        "metric_cfg": asdict(args.metric),
+    }
+
+    if args.common.format == Format.plain:
+        print(score["score"])
+    elif args.common.format == Format.json:
+        print(json.dumps(score, ensure_ascii=False, indent=2))
+
+
+def cli_main():
+    args = parse_args()
+    main(args)
+
+
+if __name__ == "__main__":
+    cli_main()

--- a/mbrs/cli/score.py
+++ b/mbrs/cli/score.py
@@ -39,8 +39,8 @@ class CommonArguments:
 
     # Hypotheses file.
     hypotheses: str = field(positional=True)
-    # Source file.
-    source: str | None = field(default=None, alias=["-s"])
+    # Sources file.
+    sources: str | None = field(default=None, alias=["-s"])
     # References file.
     references: str | None = field(default=None, alias=["-r"])
     # Output format.
@@ -71,8 +71,8 @@ def main(args: Namespace) -> None:
     num_sents = len(hypotheses)
 
     sources = None
-    if args.common.source is not None:
-        with open(args.common.source, mode="r") as f:
+    if args.common.sources is not None:
+        with open(args.common.sources, mode="r") as f:
             sources = f.readlines()
         assert num_sents == len(sources)
 

--- a/mbrs/decoders/rerank.py
+++ b/mbrs/decoders/rerank.py
@@ -27,7 +27,7 @@ class DecoderRerank(DecoderReferenceless):
             DecoderRerank.Output: The n-best hypotheses.
         """
         with timer.measure("rerank"):
-            scores = self.metric.scores(hypotheses, source=source)
+            scores = self.metric.scores(hypotheses, sources=[source] * len(hypotheses))
         topk_scores, topk_indices = self.metric.topk(scores, k=nbest)
         return self.Output(
             idx=topk_indices,

--- a/mbrs/metrics/bleu.py
+++ b/mbrs/metrics/bleu.py
@@ -59,3 +59,15 @@ class MetricBLEU(Metric):
             float: The score of the given hypothesis.
         """
         return self.scorer.sentence_score(hypothesis, [reference]).score
+
+    def corpus_score(self, hypotheses: list[str], references: list[str], *_) -> float:
+        """Calculate the corpus-level score.
+
+        Args:
+            hypotheses (list[str]): Hypotheses.
+            references (list[str]): References.
+
+        Returns:
+            float: The corpus score.
+        """
+        return self.scorer.corpus_score(hypotheses, [references]).score

--- a/mbrs/metrics/bleu_test.py
+++ b/mbrs/metrics/bleu_test.py
@@ -56,3 +56,22 @@ class TestMetricBLEU:
             atol=0.0005,
             rtol=1e-4,
         )
+
+    def test_corpus_score(self):
+        hyps = [
+            "this is a test",
+            "another test",
+            "this is a fest",
+            "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
+        ]
+        refs = [
+            "this is a test",
+            "ref",
+            "this is a test",
+            "producţia de zahăr brut se exprimă în zahăr alb;",
+        ]
+
+        metric = MetricBLEU(MetricBLEU.Config())
+        assert torch.isclose(
+            torch.tensor(metric.corpus_score(hyps, refs)), torch.tensor(22.41424)
+        )

--- a/mbrs/metrics/bleurt.py
+++ b/mbrs/metrics/bleurt.py
@@ -158,3 +158,25 @@ class MetricBLEURT(Metric):
                 model_output = self.scorer(**batch)
                 scores.append(model_output.logits.flatten())
         return torch.cat(scores).view(len(hypotheses), len(references))
+
+    def corpus_score(self, hypotheses: list[str], references: list[str]) -> float:
+        """Calculate the corpus-level score.
+
+        Args:
+            hypotheses (list[str]): Hypotheses.
+            references (list[str]): References.
+
+        Returns:
+            float: The corpus score.
+        """
+        scores = []
+        for i in range(0, len(hypotheses), self.cfg.batch_size):
+            scores.append(
+                self.scores(
+                    hypotheses[i : i + self.cfg.batch_size],
+                    references[i : i + self.cfg.batch_size],
+                )
+                .float()
+                .cpu()
+            )
+        return torch.cat(scores).mean().item()

--- a/mbrs/metrics/bleurt_test.py
+++ b/mbrs/metrics/bleurt_test.py
@@ -60,3 +60,11 @@ class TestMetricBLEURT:
             atol=0.0005 / 100,
             rtol=1e-6,
         )
+
+    def test_corpus_score(self, metric_bleurt: MetricBLEURT):
+        hyps = ["another test", "this is a test", "this is an test"]
+        refs = ["another test", "this is a fest", "this is a test"]
+        assert torch.isclose(
+            torch.tensor(metric_bleurt.corpus_score(hyps, refs)),
+            torch.FloatTensor([0.98427, 0.46749, 0.88140]).mean(),
+        )

--- a/mbrs/metrics/chrf.py
+++ b/mbrs/metrics/chrf.py
@@ -52,3 +52,15 @@ class MetricChrF(Metric):
             float: The score of the given hypothesis.
         """
         return self.scorer.sentence_score(hypothesis, [reference]).score
+
+    def corpus_score(self, hypotheses: list[str], references: list[str], *_) -> float:
+        """Calculate the corpus-level score.
+
+        Args:
+            hypotheses (list[str]): Hypotheses.
+            references (list[str]): References.
+
+        Returns:
+            float: The corpus score.
+        """
+        return self.scorer.corpus_score(hypotheses, [references]).score

--- a/mbrs/metrics/chrf_test.py
+++ b/mbrs/metrics/chrf_test.py
@@ -41,3 +41,22 @@ class TestMetricChrF:
             atol=0.0005,
             rtol=1e-4,
         )
+
+    def test_corpus_score(self):
+        hyps = [
+            "this is a test",
+            "another test",
+            "this is a fest",
+            "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
+        ]
+        refs = [
+            "this is a test",
+            "ref",
+            "this is a test",
+            "producţia de zahăr brut se exprimă în zahăr alb;",
+        ]
+
+        metric = MetricChrF(MetricChrF.Config())
+        assert torch.isclose(
+            torch.tensor(metric.corpus_score(hyps, refs)), torch.tensor(53.90979)
+        )

--- a/mbrs/metrics/comet.py
+++ b/mbrs/metrics/comet.py
@@ -84,16 +84,16 @@ class MetricCOMET(MetricCacheable):
         return embeds
 
     def out_proj(
-        self, hypotheses_ir: Tensor, references_ir: Tensor, source_ir: Tensor
+        self, hypotheses_ir: Tensor, references_ir: Tensor, sources_ir: Tensor
     ) -> Tensor:
         """Forward the output projection layer.
 
         Args:
             hypotheses_ir (Tensor): Intermediate representations of hypotheses.
             references_ir (Tensor): Intermediate representations of references.
-            source_ir (Tensor): Intermediate representations of a source.
+            sources_ir (Tensor): Intermediate representations of sources.
 
         Returns:
             Tensor: N scores.
         """
-        return self.scorer.estimate(source_ir, hypotheses_ir, references_ir)["score"]
+        return self.scorer.estimate(sources_ir, hypotheses_ir, references_ir)["score"]

--- a/mbrs/metrics/comet.py
+++ b/mbrs/metrics/comet.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass
 import torch
 from comet import download_model, load_from_checkpoint
 from torch import Tensor
+import tqdm
 
 from . import MetricCacheable, register
 
@@ -97,3 +98,29 @@ class MetricCOMET(MetricCacheable):
             Tensor: N scores.
         """
         return self.scorer.estimate(sources_ir, hypotheses_ir, references_ir)["score"]
+
+    def corpus_score(
+        self, hypotheses: list[str], references: list[str], sources: list[str]
+    ) -> float:
+        """Calculate the corpus-level score.
+
+        Args:
+            hypotheses (list[str]): Hypotheses.
+            references (list[str]): References.
+            source (list[str]): Sources.
+
+        Returns:
+            float: The corpus score.
+        """
+        scores = []
+        for i in range(0, len(hypotheses), self.cfg.batch_size):
+            scores.append(
+                self.scores(
+                    hypotheses[i : i + self.cfg.batch_size],
+                    references[i : i + self.cfg.batch_size],
+                    sources[i : i + self.cfg.batch_size],
+                )
+                .float()
+                .cpu()
+            )
+        return torch.cat(scores).mean().item()

--- a/mbrs/metrics/comet_test.py
+++ b/mbrs/metrics/comet_test.py
@@ -42,3 +42,21 @@ class TestMetricCOMET:
             atol=0.0005 / 100,
             rtol=1e-6,
         )
+
+    def test_corpus_score(self, metric_comet: MetricCOMET):
+        hyps = [
+            "this is a test",
+            "another test",
+            "this is a fest",
+            "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
+        ]
+        refs = [
+            "this is a test",
+            "ref",
+            "this is a test",
+            "producţia de zahăr brut se exprimă în zahăr alb;",
+        ]
+        assert torch.isclose(
+            torch.tensor(metric_comet.corpus_score(hyps, refs, [SOURCE] * len(hyps))),
+            torch.tensor(0.77979),
+        )

--- a/mbrs/metrics/cometqe.py
+++ b/mbrs/metrics/cometqe.py
@@ -60,19 +60,19 @@ class MetricCOMETQE(MetricReferenceless):
         Returns:
             float: The score of the given hypothesis.
         """
-        return self.scores([hypothesis], source).item()
+        return self.scores([hypothesis], [source]).item()
 
-    def scores(self, hypotheses: list[str], source: str) -> torch.Tensor:
+    def scores(self, hypotheses: list[str], sources: list[str]) -> torch.Tensor:
         """Calculate the scores of hypotheses.
 
         Args:
-            hypotheses (list[str]): Hypotheses.
-            source (str): A source.
+            hypotheses (list[str]): N hypotheses.
+            source (list[str]): N sources.
 
         Returns:
-            torch.Tensor: The scores of hypotheses.
+            torch.Tensor: N scores of the given hypotheses.
         """
-        data = [{"src": source, "mt": hyp} for hyp in hypotheses]
+        data = [{"src": src, "mt": hyp} for hyp, src in zip(hypotheses, sources)]
         scores = []
         for i in range(0, len(data), self.cfg.batch_size):
             batch = self.scorer.prepare_for_inference(data[i : i + self.cfg.batch_size])

--- a/mbrs/metrics/cometqe.py
+++ b/mbrs/metrics/cometqe.py
@@ -80,3 +80,25 @@ class MetricCOMETQE(MetricReferenceless):
             model_output = self.scorer.predict_step(batch)
             scores.append(model_output.scores)
         return torch.cat(scores).view(len(hypotheses))
+
+    def corpus_score(self, hypotheses: list[str], sources: list[str]) -> float:
+        """Calculate the corpus-level score.
+
+        Args:
+            hypotheses (list[str]): Hypotheses.
+            source (list[str]): Sources.
+
+        Returns:
+            float: The corpus score.
+        """
+        scores = []
+        for i in range(0, len(hypotheses), self.cfg.batch_size):
+            scores.append(
+                self.scores(
+                    hypotheses[i : i + self.cfg.batch_size],
+                    sources[i : i + self.cfg.batch_size],
+                )
+                .float()
+                .cpu()
+            )
+        return torch.cat(scores).mean().item()

--- a/mbrs/metrics/cometqe_test.py
+++ b/mbrs/metrics/cometqe_test.py
@@ -2,27 +2,28 @@ import torch
 
 from .cometqe import MetricCOMETQE
 
-SOURCE = "これはテストです"
 HYPOTHESES = [
     "this is a test",
     "another test",
     "this is a fest",
     "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
 ]
+SOURCES = ["これはテストです"] * len(HYPOTHESES)
+
 SCORES = torch.Tensor([0.86415, 0.83704, 0.65335, 0.29771])
 
 
 class TestMetricCOMETQE:
     def test_score(self, metric_cometqe: MetricCOMETQE):
-        for i, hyp in enumerate(HYPOTHESES):
+        for i, (hyp, src) in enumerate(zip(HYPOTHESES, SOURCES)):
             assert torch.isclose(
                 SCORES[i],
-                torch.tensor(metric_cometqe.score(hyp, SOURCE)),
+                torch.tensor(metric_cometqe.score(hyp, src)),
                 atol=0.0005 / 100,
             )
 
     def test_scores(self, metric_cometqe: MetricCOMETQE):
-        scores = metric_cometqe.scores(HYPOTHESES, SOURCE)
+        scores = metric_cometqe.scores(HYPOTHESES, SOURCES)
         torch.testing.assert_close(
             scores,
             SCORES.to(metric_cometqe.device),

--- a/mbrs/metrics/cometqe_test.py
+++ b/mbrs/metrics/cometqe_test.py
@@ -30,3 +30,15 @@ class TestMetricCOMETQE:
             atol=0.0005 / 100,
             rtol=1e-6,
         )
+
+    def test_corpus_score(self, metric_cometqe: MetricCOMETQE):
+        hyps = [
+            "this is a test",
+            "another test",
+            "this is a fest",
+            "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
+        ]
+        assert torch.isclose(
+            torch.tensor(metric_cometqe.corpus_score(hyps, SOURCES)),
+            torch.tensor(0.66306),
+        )

--- a/mbrs/metrics/ter.py
+++ b/mbrs/metrics/ter.py
@@ -57,3 +57,15 @@ class MetricTER(Metric):
             float: The score of the given hypothesis.
         """
         return self.scorer.sentence_score(hypothesis, [reference]).score
+
+    def corpus_score(self, hypotheses: list[str], references: list[str], *_) -> float:
+        """Calculate the corpus-level score.
+
+        Args:
+            hypotheses (list[str]): Hypotheses.
+            references (list[str]): References.
+
+        Returns:
+            float: The corpus score.
+        """
+        return self.scorer.corpus_score(hypotheses, [references]).score

--- a/mbrs/metrics/ter_test.py
+++ b/mbrs/metrics/ter_test.py
@@ -41,3 +41,22 @@ class TestMetricTER:
             atol=0.0005,
             rtol=1e-4,
         )
+
+    def test_corpus_score(self):
+        hyps = [
+            "this is a test",
+            "another test",
+            "this is a fest",
+            "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
+        ]
+        refs = [
+            "this is a test",
+            "ref",
+            "this is a test",
+            "producţia de zahăr brut se exprimă în zahăr alb;",
+        ]
+
+        metric = MetricTER(MetricTER.Config())
+        assert torch.isclose(
+            torch.tensor(metric.corpus_score(hyps, refs)), torch.tensor(66.66667)
+        )

--- a/mbrs/metrics/xcomet.py
+++ b/mbrs/metrics/xcomet.py
@@ -148,3 +148,32 @@ class MetricXCOMET(Metric):
                 model_output = self.scorer.predict_step(batch)
                 scores.append(model_output.scores)
         return torch.cat(scores).view(len(hypotheses), len(references))
+
+    def corpus_score(
+        self,
+        hypotheses: list[str],
+        references: Optional[list[str]] = None,
+        sources: Optional[list[str]] = None,
+    ) -> float:
+        """Calculate the corpus-level score.
+
+        Args:
+            hypotheses (list[str]): Hypotheses.
+            references (list[str], optional): References.
+            sources (list[str], optional): Sources.
+
+        Returns:
+            float: The corpus score.
+        """
+        scores = []
+        for i in range(0, len(hypotheses), self.cfg.batch_size):
+            scores.append(
+                self.scores(
+                    hypotheses[i : i + self.cfg.batch_size],
+                    references[i : i + self.cfg.batch_size] if references is not None else None,
+                    sources[i : i + self.cfg.batch_size] if sources is not None else None,
+                )
+                .float()
+                .cpu()
+            )
+        return torch.cat(scores).mean().item()

--- a/mbrs/metrics/xcomet.py
+++ b/mbrs/metrics/xcomet.py
@@ -86,14 +86,14 @@ class MetricXCOMET(Metric):
         self,
         hypotheses: list[str],
         references: Optional[list[str]] = None,
-        source: Optional[str] = None,
+        sources: Optional[list[str]] = None,
     ) -> Tensor:
         """Calculate the scores of the given hypothesis.
 
         Args:
             hypotheses (list[str]): N hypotheses.
             references (list[str], optional): N references.
-            source (str, optional): A source.
+            sources (list[str], optional): N sources.
 
         Returns:
             Tensor: The N scores of the given hypotheses.
@@ -102,9 +102,9 @@ class MetricXCOMET(Metric):
         if references is not None:
             for d, ref in zip(inputs, references):
                 d["ref"] = ref
-        if source is not None:
-            for d in inputs:
-                d["src"] = source
+        if sources is not None:
+            for d, src in zip(inputs, sources):
+                d["src"] = src
 
         scores = []
         with timer.measure("score") as t:

--- a/mbrs/metrics/xcomet_test.py
+++ b/mbrs/metrics/xcomet_test.py
@@ -41,7 +41,7 @@ class TestMetricXCOMET:
     def test_scores(self, metric_xcomet: MetricXCOMET):
         hyps = ["another test", "this is a test", "this is an test"]
         refs = ["another test", "this is a fest", "this is a test"]
-        srcs = [SOURCE] * 3
+        srcs = [SOURCE] * len(hyps)
 
         torch.testing.assert_close(
             metric_xcomet.scores(hyps, refs, srcs).cpu().float(),
@@ -69,4 +69,21 @@ class TestMetricXCOMET:
             SCORES.mean(dim=1).to(metric_xcomet.device),
             atol=0.0005 / 100,
             rtol=1e-6,
+        )
+
+    def test_corpus_score(self, metric_xcomet: MetricXCOMET):
+        hyps = ["another test", "this is a test", "this is an test"]
+        refs = ["another test", "this is a fest", "this is a test"]
+        srcs = [SOURCE] * len(hyps)
+        assert torch.isclose(
+            torch.tensor(metric_xcomet.corpus_score(hyps, refs, srcs)),
+            torch.tensor(0.96848),
+        )
+        assert torch.isclose(
+            torch.tensor(metric_xcomet.corpus_score(hyps, sources=srcs)),
+            torch.tensor(0.99120),
+        )
+        assert torch.isclose(
+            torch.tensor(metric_xcomet.corpus_score(hyps, references=refs)),
+            torch.tensor(0.92473),
         )

--- a/mbrs/metrics/xcomet_test.py
+++ b/mbrs/metrics/xcomet_test.py
@@ -41,16 +41,16 @@ class TestMetricXCOMET:
     def test_scores(self, metric_xcomet: MetricXCOMET):
         hyps = ["another test", "this is a test", "this is an test"]
         refs = ["another test", "this is a fest", "this is a test"]
-        src = SOURCE
+        srcs = [SOURCE] * 3
 
         torch.testing.assert_close(
-            metric_xcomet.scores(hyps, refs, src).cpu().float(),
+            metric_xcomet.scores(hyps, refs, srcs).cpu().float(),
             torch.FloatTensor([1.00000, 0.90545, 1.00000]),
             atol=0.0005 / 100,
             rtol=1e-6,
         )
         torch.testing.assert_close(
-            metric_xcomet.scores(hyps, source=src).cpu().float(),
+            metric_xcomet.scores(hyps, sources=srcs).cpu().float(),
             torch.FloatTensor([0.99120, 0.99120, 0.99120]),
             atol=0.0005 / 100,
             rtol=1e-6,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ pytest-cov = "^4.1.0"
 [tool.poetry.scripts]
 mbrs-decode = "mbrs.cli.decode:cli_main"
 mbrs-generate = "mbrs.cli.generate:cli_main"
+mbrs-score = "mbrs.cli.score:cli_main"
 
 [tool.coverage.run]
 omit = ["*_test.py"]


### PR DESCRIPTION
## New features
Implement `mbrs-score` to evaluate the output.
In the Python API, all metrics now have corpus_level() method to compute the corpus-level score.

## Breaking changes
This pullreq changes the scores() method to compute scores for given pairs or triplets instead of the fixed single source sentence.
