### PR TITLE
Implement model-based estimation (Jinnai et al., 2024)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,25 +115,26 @@ List of implemented methods
 
 Currently, the following metrics are supported:
 
-- BLEU: :code:`bleu` `(Papineni et al., 2002) <https://aclanthology.org/P02-1040>`_
-- TER: :code:`ter` `(Snover et al., 2006) <https://aclanthology.org/2006.amta-papers.25>`_
-- chrF: :code:`chrf` `(Popović et al., 2015) <https://aclanthology.org/W15-3049>`_
-- COMET: :code:`comet` `(Rei et al., 2020) <https://aclanthology.org/2020.emnlp-main.213>`_
-- COMETkiwi: :code:`cometqe` `(Rei et al., 2022) <https://aclanthology.org/2022.wmt-1.60>`_
-- XCOMET: :code:`xcomet` `(Guerreiro et al., 2023) <https://arxiv.org/abs/2310.10482>`_
-- BLEURT: :code:`bleurt` `(Sellam et al., 2020) <https://aclanthology.org/2020.acl-main.704>`_
+- BLEU `(Papineni et al., 2002) <https://aclanthology.org/P02-1040>`_: :code:`bleu`
+- TER `(Snover et al., 2006) <https://aclanthology.org/2006.amta-papers.25>`_: :code:`ter` 
+- chrF `(Popović et al., 2015) <https://aclanthology.org/W15-3049>`_: :code:`chrf` 
+- COMET `(Rei et al., 2020) <https://aclanthology.org/2020.emnlp-main.213>`_: :code:`comet` 
+- COMETkiwi `(Rei et al., 2022) <https://aclanthology.org/2022.wmt-1.60>`_: :code:`cometqe` 
+- XCOMET `(Guerreiro et al., 2023) <https://arxiv.org/abs/2310.10482>`_: :code:`xcomet` 
+- BLEURT `(Sellam et al., 2020) <https://aclanthology.org/2020.acl-main.704>`_: :code:`bleurt` (thanks to `@lucadiliello <https://github.com/lucadiliello/bleurt-pytorch>`_)
 
 The following decoding methods are implemented:
 
-- N-best reranking
-- MBR decoding
+- N-best reranking: :code:`rerank`
+- MBR decoding: :code:`mbr`
 
 Specifically, the following methods of MBR decoding are included:
 
-- Monte Carlo estimation: :code:`mbr` (`Eikema and Aziz, 2020 <https://aclanthology.org/2020.coling-main.398>`_; `Eikema and Aziz, 2022 <https://aclanthology.org/2022.emnlp-main.754>`_)
-- Confidence-based pruning: :code:`pruning_mbr` `(Cheng and Vlachos, 2023) <https://aclanthology.org/2023.emnlp-main.767>`_ 
-- Centroid-based MBR: :code:`cbmbr` `(Deguchi et al., 2024) <https://arxiv.org/abs/2402.11197>`_
-- Probabilistic MBR: :code:`pmbr` `(Trabelsi et al., 2024) <https://arxiv.org/abs/2406.02832>`_
+- Monte Carlo estimation (`Eikema and Aziz, 2020 <https://aclanthology.org/2020.coling-main.398>`_; `Eikema and Aziz, 2022 <https://aclanthology.org/2022.emnlp-main.754>`_)
+- Model-based estimation `(Jinnai et al., 2024) <https://arxiv.org/abs/2311.05263>`_: :code:`--reference_lprobs` option
+- Confidence-based pruning `(Cheng and Vlachos, 2023) <https://aclanthology.org/2023.emnlp-main.767>`_ : :code:`pruning_mbr`
+- Centroid-based MBR `(Deguchi et al., 2024) <https://arxiv.org/abs/2402.11197>`_: :code:`cbmbr`
+- Probabilistic MBR `(Trabelsi et al., 2024) <https://arxiv.org/abs/2406.02832>`_: :code:`pmbr`
 
 Citation
 ========

--- a/mbrs/decoders/__init__.py
+++ b/mbrs/decoders/__init__.py
@@ -1,6 +1,6 @@
 from mbrs import registry
 
-from .base import DecoderReferenceBased, DecoderReferenceless
+from .base import DecoderBase, DecoderReferenceBased, DecoderReferenceless
 
 register, get_decoder = registry.setup("decoder")
 
@@ -11,6 +11,7 @@ from .pruning_mbr import DecoderPruningMBR
 from .rerank import DecoderRerank
 
 __all__ = [
+    "DecoderBase",
     "DecoderReferenceBased",
     "DecoderReferenceless",
     "DecoderMBR",

--- a/mbrs/decoders/base.py
+++ b/mbrs/decoders/base.py
@@ -4,6 +4,8 @@ import abc
 from dataclasses import dataclass
 from typing import Optional
 
+from torch import Tensor
+
 from mbrs.metrics.base import Metric, MetricBase, MetricReferenceless
 
 
@@ -43,6 +45,7 @@ class DecoderReferenceBased(DecoderBase, metaclass=abc.ABCMeta):
         references: list[str],
         source: Optional[str] = None,
         nbest: int = 1,
+        reference_lprobs: Optional[Tensor] = None,
     ) -> DecoderReferenceBased.Output:
         """Select the n-best hypotheses based on the strategy.
 
@@ -51,6 +54,8 @@ class DecoderReferenceBased(DecoderBase, metaclass=abc.ABCMeta):
             references (list[str]): References.
             source (str, optional): A source.
             nbest (int): Return the n-best hypotheses.
+            reference_lprobs (Tensor, optional): Log-probabilities for each reference sample.
+              The shape must be `(len(references),)`. See `https://arxiv.org/abs/2311.05263`.
 
         Returns:
             Decoder.Output: The n-best hypotheses.

--- a/mbrs/decoders/cbmbr_test.py
+++ b/mbrs/decoders/cbmbr_test.py
@@ -51,3 +51,18 @@ class TestDecoderCBMBR:
                 SCORES[i],
                 atol=0.0005 / 100,
             )
+
+            output = decoder.decode(
+                hyps,
+                refs,
+                SOURCE[i],
+                nbest=1,
+                reference_lprobs=torch.Tensor([-2.000]).repeat(len(refs)),
+            )
+            assert output.idx[0] == BEST_INDICES[i]
+            assert output.sentence[0] == BEST_SENTENCES[i]
+            assert torch.isclose(
+                torch.tensor(output.score[0]),
+                SCORES[i],
+                atol=0.0005 / 100,
+            )

--- a/mbrs/decoders/mbr.py
+++ b/mbrs/decoders/mbr.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Optional
 
+from torch import Tensor
+
 from . import DecoderReferenceBased, register
 
 
@@ -29,6 +31,7 @@ class DecoderMBR(DecoderReferenceBased):
         references: list[str],
         source: Optional[str] = None,
         nbest: int = 1,
+        reference_lprobs: Optional[Tensor] = None,
     ) -> DecoderMBR.Output:
         """Select the n-best hypotheses based on the strategy.
 
@@ -37,11 +40,15 @@ class DecoderMBR(DecoderReferenceBased):
             references (list[str]): References.
             source (str, optional): A source.
             nbest (int): Return the n-best hypotheses.
+            reference_lprobs (Tensor, optional): Log-probabilities for each reference sample.
+              The shape must be `(len(references),)`. See `https://arxiv.org/abs/2311.05263`.
 
         Returns:
             DecoderMBR.Output: The n-best hypotheses.
         """
-        expected_scores = self.metric.expected_scores(hypotheses, references, source)
+        expected_scores = self.metric.expected_scores(
+            hypotheses, references, source, reference_lprobs=reference_lprobs
+        )
         topk_scores, topk_indices = self.metric.topk(expected_scores, k=nbest)
         return self.Output(
             idx=topk_indices,

--- a/mbrs/decoders/mbr_test.py
+++ b/mbrs/decoders/mbr_test.py
@@ -34,11 +34,29 @@ SCORES = {
 
 class TestDecoderMBR:
     @pytest.mark.parametrize("metric_type", ["bleu", "ter"])
-    def test_decode(self, metric_type: str):
+    @pytest.mark.parametrize("nbest", [1, 2])
+    def test_decode(self, metric_type: str, nbest: int):
         metric_cls = get_metric(metric_type)
         decoder = DecoderMBR(DecoderMBR.Config(), metric_cls(metric_cls.Config()))
         for i, (hyps, refs) in enumerate(zip(HYPOTHESES, REFERENCES)):
-            output = decoder.decode(hyps, refs, nbest=1)
+            output = decoder.decode(hyps, refs, nbest=nbest, reference_lprobs=None)
+            assert output.idx[0] == BEST_INDICES[i]
+            assert output.sentence[0] == BEST_SENTENCES[i]
+            assert len(output.sentence) == min(nbest, len(hyps))
+            assert len(output.score) == min(nbest, len(hyps))
+            torch.testing.assert_close(
+                torch.tensor(output.score[0]),
+                SCORES[metric_type][i],
+                atol=0.0005,
+                rtol=1e-4,
+            )
+
+            output = decoder.decode(
+                hyps,
+                refs,
+                nbest=1,
+                reference_lprobs=torch.Tensor([-2.000]).repeat(len(refs)),
+            )
             assert output.idx[0] == BEST_INDICES[i]
             assert output.sentence[0] == BEST_SENTENCES[i]
             torch.testing.assert_close(

--- a/mbrs/decoders/pmbr_test.py
+++ b/mbrs/decoders/pmbr_test.py
@@ -1,4 +1,4 @@
-import numpy as np
+import torch
 
 from mbrs.metrics.chrf import MetricChrF
 from mbrs.metrics.comet import MetricCOMET
@@ -31,8 +31,6 @@ BEST_SENTENCES = [
     "this is a test",
     "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
 ]
-SCORES_COMET = np.array([0.84780, 0.85304, 0.99257, 0.78060], dtype=np.float32)
-SCORES_CHRF = np.array([48.912, 44.239, 100.0, 46.161], dtype=np.float32)
 
 NITER = 30
 FACTOR = 1.25
@@ -62,5 +60,15 @@ class TestDecoderProbabilisticMBR:
         )
         for i, (hyps, refs) in enumerate(zip(HYPOTHESES, REFERENCES)):
             output = decoder.decode(hyps, refs, SOURCE[i], nbest=1)
+            assert output.idx[0] == BEST_INDICES[i]
+            assert output.sentence[0] == BEST_SENTENCES[i]
+
+            output = decoder.decode(
+                hyps,
+                refs,
+                SOURCE[i],
+                nbest=1,
+                reference_lprobs=torch.Tensor([-2.000]).repeat(len(refs)),
+            )
             assert output.idx[0] == BEST_INDICES[i]
             assert output.sentence[0] == BEST_SENTENCES[i]

--- a/mbrs/decoders/pruning_mbr_test.py
+++ b/mbrs/decoders/pruning_mbr_test.py
@@ -1,4 +1,5 @@
 import numpy as np
+import torch
 
 from mbrs.metrics.chrf import MetricChrF
 from mbrs.metrics.comet import MetricCOMET
@@ -43,6 +44,19 @@ class TestDecoderPruningMBR:
         )
         for i, (hyps, refs) in enumerate(zip(HYPOTHESES, REFERENCES)):
             output = decoder.decode(hyps, refs, SOURCE[i], nbest=1)
+            assert output.idx[0] == BEST_INDICES[i]
+            assert output.sentence[0] == BEST_SENTENCES[i]
+            assert np.allclose(
+                np.array(output.score[0], dtype=np.float32), SCORES_CHRF[i], atol=0.0005
+            )
+
+            output = decoder.decode(
+                hyps,
+                refs,
+                SOURCE[i],
+                nbest=1,
+                reference_lprobs=torch.Tensor([-2.000]).repeat(len(refs)),
+            )
             assert output.idx[0] == BEST_INDICES[i]
             assert output.sentence[0] == BEST_SENTENCES[i]
             assert np.allclose(

--- a/mbrs/functional.py
+++ b/mbrs/functional.py
@@ -1,0 +1,27 @@
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+def expectation(matrix: Tensor, lprobs: Optional[Tensor] = None) -> Tensor:
+    """Compute expectation values for each row.
+
+    Args:
+        matrix (Tensor): Input matrix of shape `(H, R)`.
+        lprobs (Tensor, optional): Log-probabilities for each column of shape `(R,)`.
+
+    Returns:
+        Tensor: Expected values for each row of shape `(H,)`.
+    """
+    if lprobs is None:
+        return matrix.mean(dim=-1)
+    else:
+        if list(lprobs.shape) != list(matrix.shape)[1:]:
+            raise ValueError(
+                f"`weights` must have {list(matrix.shape)[1:]} elements, but got {list(lprobs.shape)}"
+            )
+
+        return (
+            matrix * lprobs.softmax(dim=-1, dtype=torch.float32).to(matrix)[None, :]
+        ).sum(dim=-1)

--- a/mbrs/functional_test.py
+++ b/mbrs/functional_test.py
@@ -1,0 +1,28 @@
+from typing import Optional
+
+import pytest
+import torch
+from torch import Tensor
+
+from .functional import expectation
+
+H = 8
+R = 5
+
+A = torch.rand(H, R)
+
+
+@pytest.mark.parametrize(
+    "lprobs", [None, torch.FloatTensor([-3.0, -2.4, -1.9, -5.5, -4.3])]
+)
+def test_expectation(lprobs: Optional[Tensor]):
+    e = expectation(A, lprobs=lprobs)
+    assert list(e.shape) == [H]
+    if lprobs is None:
+        assert torch.allclose(e, A.mean(dim=-1))
+    else:
+        with pytest.raises(ValueError):
+            expectation(torch.rand(H, R - 1), lprobs=lprobs)
+
+        weights = lprobs.exp() / lprobs.exp().sum(dim=-1, keepdim=True)
+        assert torch.allclose(e, (A @ weights[None, :].T).squeeze(-1))


### PR DESCRIPTION
Implement https://arxiv.org/abs/2311.05263.
In `mbrs-decode`, log-probabilities file can be passed via `--reference_lprobs`.