### PR TITLE
Rename modules and classes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,11 +116,11 @@ List of implemented methods
 Currently, the following metrics are supported:
 
 - BLEU `(Papineni et al., 2002) <https://aclanthology.org/P02-1040>`_: :code:`bleu`
-- TER `(Snover et al., 2006) <https://aclanthology.org/2006.amta-papers.25>`_: :code:`ter` 
-- chrF `(Popović et al., 2015) <https://aclanthology.org/W15-3049>`_: :code:`chrf` 
-- COMET `(Rei et al., 2020) <https://aclanthology.org/2020.emnlp-main.213>`_: :code:`comet` 
-- COMETkiwi `(Rei et al., 2022) <https://aclanthology.org/2022.wmt-1.60>`_: :code:`cometqe` 
-- XCOMET `(Guerreiro et al., 2023) <https://arxiv.org/abs/2310.10482>`_: :code:`xcomet` 
+- TER `(Snover et al., 2006) <https://aclanthology.org/2006.amta-papers.25>`_: :code:`ter`
+- chrF `(Popović et al., 2015) <https://aclanthology.org/W15-3049>`_: :code:`chrf`
+- COMET `(Rei et al., 2020) <https://aclanthology.org/2020.emnlp-main.213>`_: :code:`comet`
+- COMETkiwi `(Rei et al., 2022) <https://aclanthology.org/2022.wmt-1.60>`_: :code:`cometkiwi`
+- XCOMET `(Guerreiro et al., 2023) <https://arxiv.org/abs/2310.10482>`_: :code:`xcomet`
 - BLEURT `(Sellam et al., 2020) <https://aclanthology.org/2020.acl-main.704>`_: :code:`bleurt` (thanks to `@lucadiliello <https://github.com/lucadiliello/bleurt-pytorch>`_)
 
 The following decoding methods are implemented:
@@ -144,8 +144,8 @@ Specifically, the following methods of MBR decoding are included:
     - N-gram aggregation on chrF `(Vamvas and Sennrich, 2024) <https://arxiv.org/abs/2402.04251>`_
     - Embedding aggregation on COMET (`Vamvas and Sennrich, 2024 <https://arxiv.org/abs/2402.04251>`_; `Deguchi et al., 2024 <https://arxiv.org/abs/2402.11197>`_)
 
-  - Centroid-based MBR `(Deguchi et al., 2024) <https://arxiv.org/abs/2402.11197>`_: :code:`cbmbr`
-  - Probabilistic MBR `(Trabelsi et al., 2024) <https://arxiv.org/abs/2406.02832>`_: :code:`pmbr`
+  - Centroid-based MBR `(Deguchi et al., 2024) <https://arxiv.org/abs/2402.11197>`_: :code:`centroid_mbr`
+  - Probabilistic MBR `(Trabelsi et al., 2024) <https://arxiv.org/abs/2406.02832>`_: :code:`probabilistic_mbr`
 
 Related projects
 ================

--- a/mbrs/conftest.py
+++ b/mbrs/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from mbrs.metrics import MetricCOMET, MetricCOMETQE, MetricXCOMET, MetricBLEURT
+from mbrs.metrics import MetricBLEURT, MetricCOMET, MetricCOMETkiwi, MetricXCOMET
 
 
 @pytest.fixture(scope="session")
@@ -10,8 +10,8 @@ def metric_comet():
 
 
 @pytest.fixture(scope="session")
-def metric_cometqe():
-    return MetricCOMETQE(MetricCOMETQE.Config())
+def metric_cometkiwi():
+    return MetricCOMETkiwi(MetricCOMETkiwi.Config())
 
 
 @pytest.mark.skipif(

--- a/mbrs/decoders/__init__.py
+++ b/mbrs/decoders/__init__.py
@@ -6,8 +6,8 @@ register, get_decoder = registry.setup("decoder")
 
 from .mbr import DecoderMBR
 from .aggregate_mbr import DecoderAggregateMBR
-from .cbmbr import DecoderCBMBR
-from .pmbr import DecoderProbabilisticMBR
+from .centroid_mbr import DecoderCentroidMBR
+from .probabilistic_mbr import DecoderProbabilisticMBR
 from .pruning_mbr import DecoderPruningMBR
 from .rerank import DecoderRerank
 
@@ -17,7 +17,7 @@ __all__ = [
     "DecoderReferenceless",
     "DecoderMBR",
     "DecoderAggregateMBR",
-    "DecoderCBMBR",
+    "DecoderCentroidMBR",
     "DecoderProbabilisticMBR",
     "DecoderPruningMBR",
     "DecoderRerank",

--- a/mbrs/decoders/centroid_mbr.py
+++ b/mbrs/decoders/centroid_mbr.py
@@ -13,8 +13,8 @@ from . import register
 from .mbr import DecoderMBR
 
 
-@register("cbmbr")
-class DecoderCBMBR(DecoderMBR):
+@register("centroid_mbr")
+class DecoderCentroidMBR(DecoderMBR):
     """Centroid-Based MBR decoder class.
 
     - Time complexity: O(Nk)
@@ -57,7 +57,7 @@ class DecoderCBMBR(DecoderMBR):
         source: Optional[str] = None,
         nbest: int = 1,
         reference_lprobs: Optional[Tensor] = None,
-    ) -> DecoderCBMBR.Output:
+    ) -> DecoderCentroidMBR.Output:
         """Select the n-best hypotheses based on the strategy.
 
         Args:

--- a/mbrs/decoders/centroid_mbr_test.py
+++ b/mbrs/decoders/centroid_mbr_test.py
@@ -4,7 +4,7 @@ import torch
 from mbrs.decoders.aggregate_mbr import DecoderAggregateMBR
 from mbrs.metrics.comet import MetricCOMET
 
-from .cbmbr import DecoderCBMBR
+from .centroid_mbr import DecoderCentroidMBR
 
 SOURCE = [
     "これはテストです",
@@ -40,8 +40,8 @@ NCENTROIDS = 2
 class TestDecoderCBMBR:
     @pytest.mark.parametrize("kmeanspp", [True, False])
     def test_decode(self, metric_comet: MetricCOMET, kmeanspp: bool):
-        decoder = DecoderCBMBR(
-            DecoderCBMBR.Config(ncentroids=NCENTROIDS, kmeanspp=kmeanspp), metric_comet
+        decoder = DecoderCentroidMBR(
+            DecoderCentroidMBR.Config(ncentroids=NCENTROIDS, kmeanspp=kmeanspp), metric_comet
         )
         for i, (hyps, refs) in enumerate(zip(HYPOTHESES, REFERENCES)):
             output = decoder.decode(hyps, refs, SOURCE[i], nbest=1)
@@ -72,8 +72,8 @@ class TestDecoderCBMBR:
     def test_decode_equivalent_with_aggregate(
         self, metric_comet: MetricCOMET, kmeanspp: bool
     ):
-        decoder_cbmbr = DecoderCBMBR(
-            DecoderCBMBR.Config(ncentroids=1, kmeanspp=kmeanspp), metric_comet
+        decoder_cbmbr = DecoderCentroidMBR(
+            DecoderCentroidMBR.Config(ncentroids=1, kmeanspp=kmeanspp), metric_comet
         )
         decoder_aggregate = DecoderAggregateMBR(
             DecoderAggregateMBR.Config(), metric_comet

--- a/mbrs/decoders/probabilistic_mbr.py
+++ b/mbrs/decoders/probabilistic_mbr.py
@@ -15,7 +15,7 @@ from . import register
 from .mbr import DecoderMBR
 
 
-@register("pmbr")
+@register("probabilistic_mbr")
 class DecoderProbabilisticMBR(DecoderMBR):
     """Probablistic MBR decoder using alternating least squares (ALS) approximation.
 

--- a/mbrs/decoders/probabilistic_mbr_test.py
+++ b/mbrs/decoders/probabilistic_mbr_test.py
@@ -3,7 +3,7 @@ import torch
 from mbrs.metrics.chrf import MetricChrF
 from mbrs.metrics.comet import MetricCOMET
 
-from .pmbr import DecoderProbabilisticMBR
+from .probabilistic_mbr import DecoderProbabilisticMBR
 
 SOURCE = [
     "これはテストです",

--- a/mbrs/decoders/rerank_test.py
+++ b/mbrs/decoders/rerank_test.py
@@ -1,6 +1,6 @@
 import torch
 
-from mbrs.metrics.cometqe import MetricCOMETQE
+from mbrs.metrics.cometkiwi import MetricCOMETkiwi
 
 from .rerank import DecoderRerank
 
@@ -23,8 +23,8 @@ SCORES = torch.Tensor([0.86415, 0.86415, 0.86415, 0.29771])
 
 
 class TestDecoderRerank:
-    def test_decode(self, metric_cometqe: MetricCOMETQE):
-        decoder = DecoderRerank(DecoderRerank.Config(), metric_cometqe)
+    def test_decode(self, metric_cometkiwi: MetricCOMETkiwi):
+        decoder = DecoderRerank(DecoderRerank.Config(), metric_cometkiwi)
         for i, hyps in enumerate(HYPOTHESES):
             output = decoder.decode(hyps, SOURCE, nbest=1)
             assert output.idx[0] == BEST_INDICES[i]

--- a/mbrs/metrics/__init__.py
+++ b/mbrs/metrics/__init__.py
@@ -7,7 +7,7 @@ register, get_metric = registry.setup("metric")
 from .bleu import MetricBLEU
 from .chrf import MetricChrF
 from .comet import MetricCOMET
-from .cometqe import MetricCOMETQE
+from .cometkiwi import MetricCOMETkiwi
 from .ter import MetricTER
 from .xcomet import MetricXCOMET
 from .bleurt import MetricBLEURT
@@ -20,7 +20,7 @@ __all__ = [
     "MetricBLEU",
     "MetricChrF",
     "MetricCOMET",
-    "MetricCOMETQE",
+    "MetricCOMETkiwi",
     "MetricTER",
     "MetricXCOMET",
     "MetricBLEURT",

--- a/mbrs/metrics/cometkiwi.py
+++ b/mbrs/metrics/cometkiwi.py
@@ -10,13 +10,13 @@ from mbrs import utils
 from . import MetricReferenceless, register
 
 
-@register("cometqe")
-class MetricCOMETQE(MetricReferenceless):
-    """COMET-QE metric class."""
+@register("cometkiwi")
+class MetricCOMETkiwi(MetricReferenceless):
+    """COMETkiwi metric class."""
 
     @dataclass
     class Config(MetricReferenceless.Config):
-        """COMET-QE metric configuration.
+        """COMETkiwi metric configuration.
 
         - model (str): Model name or path.
         - batch_size (int): Batch size.
@@ -31,7 +31,7 @@ class MetricCOMETQE(MetricReferenceless):
         bf16: bool = False
         cpu: bool = False
 
-    def __init__(self, cfg: MetricCOMETQE.Config):
+    def __init__(self, cfg: MetricCOMETkiwi.Config):
         self.cfg = cfg
         self.scorer = load_from_checkpoint(download_model(cfg.model))
         self.scorer.eval()

--- a/mbrs/metrics/cometkiwi_test.py
+++ b/mbrs/metrics/cometkiwi_test.py
@@ -1,6 +1,6 @@
 import torch
 
-from .cometqe import MetricCOMETQE
+from .cometkiwi import MetricCOMETkiwi
 
 HYPOTHESES = [
     "this is a test",
@@ -14,24 +14,24 @@ SCORES = torch.Tensor([0.86415, 0.83704, 0.65335, 0.29771])
 
 
 class TestMetricCOMETQE:
-    def test_score(self, metric_cometqe: MetricCOMETQE):
+    def test_score(self, metric_cometkiwi: MetricCOMETkiwi):
         for i, (hyp, src) in enumerate(zip(HYPOTHESES, SOURCES)):
             assert torch.isclose(
                 SCORES[i],
-                torch.tensor(metric_cometqe.score(hyp, src)),
+                torch.tensor(metric_cometkiwi.score(hyp, src)),
                 atol=0.0005 / 100,
             )
 
-    def test_scores(self, metric_cometqe: MetricCOMETQE):
-        scores = metric_cometqe.scores(HYPOTHESES, SOURCES)
+    def test_scores(self, metric_cometkiwi: MetricCOMETkiwi):
+        scores = metric_cometkiwi.scores(HYPOTHESES, SOURCES)
         torch.testing.assert_close(
             scores,
-            SCORES.to(metric_cometqe.device),
+            SCORES.to(metric_cometkiwi.device),
             atol=0.0005 / 100,
             rtol=1e-6,
         )
 
-    def test_corpus_score(self, metric_cometqe: MetricCOMETQE):
+    def test_corpus_score(self, metric_cometkiwi: MetricCOMETkiwi):
         hyps = [
             "this is a test",
             "another test",
@@ -39,6 +39,6 @@ class TestMetricCOMETQE:
             "Producția de zahăr primă va fi exprimată în ceea ce privește zahărul alb;",
         ]
         assert torch.isclose(
-            torch.tensor(metric_cometqe.corpus_score(hyps, SOURCES)),
+            torch.tensor(metric_cometkiwi.corpus_score(hyps, SOURCES)),
             torch.tensor(0.66306),
         )


### PR DESCRIPTION
This commit has backward incompatible changes.

- Rename classes

  - `MetricCOMETQE` -> `MetricCOMETkiwi`
  - `DecoderCBMBR` -> `DecoderCentroidMBR`

- Rename registry names

  - `cometqe` -> `cometkiwi`
  - `cbmbr` -> `centroid_mbr`
  - `pmbr` -> `probabilistic_mbr`