### PR TITLE
Implement xCOMET-lite (Larionov et al., 2024)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ Currently, the following metrics are supported:
     2022)](https://aclanthology.org/2022.wmt-1.60): `cometkiwi`
 -   XCOMET [(Guerreiro et al., 2023)](https://doi.org/10.1162/tacl_a_00683):
     `xcomet`
+-   XCOMET-lite [(Larionov et al., 2024)](https://aclanthology.org/2024.emnlp-main.1223):
+    `xcomet`
 -   BLEURT [(Sellam et al.,
     2020)](https://aclanthology.org/2020.acl-main.704): `bleurt` (thanks
     to [\@lucadiliello](https://github.com/lucadiliello/bleurt-pytorch))

--- a/docs/list_metrics.rst
+++ b/docs/list_metrics.rst
@@ -39,6 +39,10 @@ Supported metrics are listed below.
      - :code:`xcomet`
      - :doc:`MetricXCOMET <./source/mbrs.metrics.xcomet>`
      - `(Guerreiro et al., 2023) <https://doi.org/10.1162/tacl_a_00683>`_
+   * - XCOMET-lite
+     - :code:`xcomet`
+     - :doc:`MetricXCOMET <./source/mbrs.metrics.xcomet>`
+     - `(Larionov et al., 2024) <https://aclanthology.org/2024.emnlp-main.1223>`_
    * - BLEURT
      - :code:`bleurt`
      - :doc:`MetricBLEURT <./source/mbrs.metrics.bleurt>`

--- a/mbrs/metrics/xcomet.py
+++ b/mbrs/metrics/xcomet.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from typing import Optional
 
@@ -32,6 +33,7 @@ class DeBERTaEncoder(BERTEncoder):
         self, pretrained_model: str, load_pretrained_weights: bool = True
     ) -> None:
         super(Encoder, self).__init__()
+        os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
         self.tokenizer = AutoTokenizer.from_pretrained(pretrained_model)
         if load_pretrained_weights:
             self.model = AutoModel.from_pretrained(pretrained_model)

--- a/mbrs/metrics/xcomet.py
+++ b/mbrs/metrics/xcomet.py
@@ -3,14 +3,120 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
+import comet.encoders
 import torch
 from comet import download_model, load_from_checkpoint
+from comet.encoders.base import Encoder
+from comet.encoders.bert import BERTEncoder
 from comet.models import XCOMETMetric
-from torch import Tensor
+from huggingface_hub import PyTorchModelHubMixin
+from torch import Tensor, nn
+from transformers import AutoConfig, AutoModel, AutoTokenizer
+from transformers.models.deberta_v2 import modeling_deberta_v2
 
 from mbrs import timer, utils
 
 from . import Metric, register
+
+
+class DeBERTaEncoder(BERTEncoder):
+    """DeBERTa encoder.
+
+    Args:
+        pretrained_model (str): Pretrained model from hugging face.
+        load_pretrained_weights (bool): If set to True loads the pretrained weights
+            from Hugging Face
+    """
+
+    def __init__(
+        self, pretrained_model: str, load_pretrained_weights: bool = True
+    ) -> None:
+        super(Encoder, self).__init__()
+        self.tokenizer = AutoTokenizer.from_pretrained(pretrained_model)
+        if load_pretrained_weights:
+            self.model = AutoModel.from_pretrained(pretrained_model)
+        else:
+            self.model = AutoModel.from_config(
+                AutoConfig.from_pretrained(pretrained_model),
+            )
+        self.model.encoder.output_hidden_states = True
+
+        self.model.encoder.layer = nn.ModuleList(
+            [
+                modeling_deberta_v2.DebertaV2Layer(
+                    AutoConfig.from_pretrained(pretrained_model)
+                )
+                for _ in range(self.model.config.num_hidden_layers)
+            ]
+        )
+
+    @classmethod
+    def from_pretrained(
+        cls, pretrained_model: str, load_pretrained_weights: bool = True
+    ) -> Encoder:
+        """Function that loads a pretrained encoder from Hugging Face.
+
+        Args:
+            pretrained_model (str):Name of the pretrain model to be loaded.
+            load_pretrained_weights (bool): If set to True loads the pretrained weights
+                from Hugging Face
+
+        Returns:
+            DeBERTaEncoder: DeBERTaEncoder object.
+        """
+        return DeBERTaEncoder(pretrained_model, load_pretrained_weights)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        token_type_ids: Optional[torch.Tensor] = None,
+        **kwargs,
+    ) -> dict[str, torch.Tensor]:
+        if attention_mask is None:
+            attention_mask = torch.ones_like(input_ids)
+
+        model_output = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            token_type_ids=token_type_ids,
+            output_hidden_states=True,
+        )
+        return {
+            "sentemb": model_output.last_hidden_state[:, 0, :],
+            "wordemb": model_output.last_hidden_state,
+            "all_layers": model_output.hidden_states,
+            "attention_mask": attention_mask,
+        }
+
+
+class XCOMETLiteMetric(XCOMETMetric, PyTorchModelHubMixin):
+    """xCOMET-Lite model."""
+
+    def __init__(
+        self,
+        encoder_model="DeBERTa",
+        pretrained_model="microsoft/mdeberta-v3-base",
+        word_layer=8,
+        validation_data=[],
+        word_level_training=True,
+        hidden_sizes=(3072, 1024),
+        load_pretrained_weights=False,
+        *args,
+        **kwargs,
+    ):
+        comet.encoders.str2encoder["DeBERTa"] = DeBERTaEncoder
+        super().__init__(
+            encoder_model=encoder_model,
+            pretrained_model=pretrained_model,
+            word_layer=word_layer,
+            validation_data=validation_data,
+            word_level_training=word_level_training,
+            hidden_sizes=hidden_sizes,
+            load_pretrained_weights=load_pretrained_weights,
+            *args,
+            **kwargs,
+        )
 
 
 @register("xcomet")
@@ -38,7 +144,10 @@ class MetricXCOMET(Metric):
 
     def __init__(self, cfg: MetricXCOMET.Config):
         self.cfg = cfg
-        self.scorer = load_from_checkpoint(download_model(cfg.model))
+        if cfg.model == "myyycroft/XCOMET-lite":
+            self.scorer = XCOMETLiteMetric.from_pretrained(cfg.model)
+        else:
+            self.scorer = load_from_checkpoint(download_model(cfg.model))
         self.scorer.eval()
         for param in self.scorer.parameters():
             param.requires_grad = False
@@ -170,8 +279,12 @@ class MetricXCOMET(Metric):
             scores.append(
                 self.scores(
                     hypotheses[i : i + self.cfg.batch_size],
-                    references[i : i + self.cfg.batch_size] if references is not None else None,
-                    sources[i : i + self.cfg.batch_size] if sources is not None else None,
+                    references[i : i + self.cfg.batch_size]
+                    if references is not None
+                    else None,
+                    sources[i : i + self.cfg.batch_size]
+                    if sources is not None
+                    else None,
                 )
                 .float()
                 .cpu()

--- a/mbrs/metrics/xcomet_test.py
+++ b/mbrs/metrics/xcomet_test.py
@@ -15,12 +15,20 @@ REFERENCES = [
     "this is a test",
     "producţia de zahăr brut se exprimă în zahăr alb;",
 ]
-SCORES = torch.Tensor(
+SCORES_XCOMET = torch.Tensor(
     [
         [0.97671, 1.00000, 0.49054],
         [0.94399, 0.99120, 0.43007],
         [0.71786, 0.71210, 0.30775],
         [0.21788, 0.22079, 0.61004],
+    ]
+)
+SCORES_XCOMETLITE = torch.Tensor(
+    [
+        [0.75441, 0.93626, 0.52062],
+        [0.65309, 0.74183, 0.42666],
+        [0.42499, 0.52537, 0.36234],
+        [0.36428, 0.36428, 0.70672],
     ]
 )
 
@@ -33,7 +41,7 @@ class TestMetricXCOMET:
         for i, hyp in enumerate(HYPOTHESES):
             for j, ref in enumerate(REFERENCES):
                 assert torch.isclose(
-                    SCORES[i, j],
+                    SCORES_XCOMET[i, j],
                     torch.tensor(metric_xcomet.score(hyp, ref, SOURCE)),
                     atol=0.0005 / 100,
                 )
@@ -66,7 +74,7 @@ class TestMetricXCOMET:
         expected_scores = metric_xcomet.expected_scores(HYPOTHESES, REFERENCES, SOURCE)
         torch.testing.assert_close(
             expected_scores,
-            SCORES.mean(dim=1).to(metric_xcomet.device),
+            SCORES_XCOMET.mean(dim=1).to(metric_xcomet.device),
             atol=0.0005 / 100,
             rtol=1e-6,
         )
@@ -86,4 +94,71 @@ class TestMetricXCOMET:
         assert torch.isclose(
             torch.tensor(metric_xcomet.corpus_score(hyps, references=refs)),
             torch.tensor(0.92473),
+        )
+
+
+class TestMetricXCOMETLite:
+    @pytest.fixture(scope="class")
+    def metric_xcometlite(self):
+        return MetricXCOMET(MetricXCOMET.Config(model="myyycroft/XCOMET-lite"))
+
+    def test_score(self, metric_xcometlite: MetricXCOMET):
+        for i, hyp in enumerate(HYPOTHESES):
+            for j, ref in enumerate(REFERENCES):
+                assert torch.isclose(
+                    SCORES_XCOMETLITE[i, j],
+                    torch.tensor(metric_xcometlite.score(hyp, ref, SOURCE)),
+                    atol=0.0005 / 100,
+                )
+
+    def test_scores(self, metric_xcometlite: MetricXCOMET):
+        hyps = ["another test", "this is a test", "this is an test"]
+        refs = ["another test", "this is a fest", "this is a test"]
+        srcs = [SOURCE] * len(hyps)
+
+        torch.testing.assert_close(
+            metric_xcometlite.scores(hyps, refs, srcs).cpu().float(),
+            torch.FloatTensor([0.8399, 0.6973, 0.9058]),
+            atol=0.0005 / 100,
+            rtol=1e-4,
+        )
+        torch.testing.assert_close(
+            metric_xcometlite.scores(hyps, sources=srcs).cpu().float(),
+            torch.FloatTensor([0.7146, 0.9707, 0.9416]),
+            atol=0.0005 / 100,
+            rtol=1e-4,
+        )
+        torch.testing.assert_close(
+            metric_xcometlite.scores(hyps, references=refs).cpu().float(),
+            torch.FloatTensor([0.9112, 0.4744, 0.8681]),
+            atol=0.0005 / 100,
+            rtol=1e-4,
+        )
+
+    def test_expected_scores(self, metric_xcometlite: MetricXCOMET):
+        expected_scores = metric_xcometlite.expected_scores(
+            HYPOTHESES, REFERENCES, SOURCE
+        )
+        torch.testing.assert_close(
+            expected_scores,
+            SCORES_XCOMETLITE.mean(dim=1).to(metric_xcometlite.device),
+            atol=0.0005 / 100,
+            rtol=1e-6,
+        )
+
+    def test_corpus_score(self, metric_xcometlite: MetricXCOMET):
+        hyps = ["another test", "this is a test", "this is an test"]
+        refs = ["another test", "this is a fest", "this is a test"]
+        srcs = [SOURCE] * len(hyps)
+        assert torch.isclose(
+            torch.tensor(metric_xcometlite.corpus_score(hyps, refs, srcs)),
+            torch.tensor(0.81435),
+        )
+        assert torch.isclose(
+            torch.tensor(metric_xcometlite.corpus_score(hyps, sources=srcs)),
+            torch.tensor(0.87564),
+        )
+        assert torch.isclose(
+            torch.tensor(metric_xcometlite.corpus_score(hyps, references=refs)),
+            torch.tensor(0.75123),
         )


### PR DESCRIPTION
Support xCOMET-lite, the distilled version of xCOMET model.
The metrics class is not separated from the original xCOMET and just needed to specify the huggignface model name to `myyycroft/XCOMET-lite`.