### PR TITLE
Implement plug-in module loader

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -30,6 +30,7 @@ mbrs: A library for MBR decoding
       - :doc:`design`
       - :doc:`custom_metric`
       - :doc:`custom_decoder`
+      - :doc:`plugin`
       - :doc:`timer`
 
    .. grid-item-card:: :material-regular:`library_books;2em` References
@@ -66,6 +67,7 @@ mbrs: A library for MBR decoding
    design
    custom_metric
    custom_decoder
+   plugin
    timer
 
 .. toctree::

--- a/docs/plugin.rst
+++ b/docs/plugin.rst
@@ -47,7 +47,7 @@ This tutorial explains how to load a user defined modules.
         --decoder mbr \
         --metric my_bleu
 
-   `mbrs-score` also supports plug-in loading.
+   :code:`mbrs-score` also supports plug-in loading.
 
    .. code-block:: bash
       :emphasize-lines: 2,5

--- a/docs/plugin.rst
+++ b/docs/plugin.rst
@@ -1,0 +1,59 @@
+Plug-in loader
+==============
+
+:code:`mbrs-decode` and :code:`mbrs-score` load plug-in modules via the :code:`--plugin_dir` option.
+
+Examples
+~~~~~~~~
+
+This tutorial explains how to load a user defined modules.
+
+.. seealso::
+
+   :doc:`How to define a new metric <./custom_metric>`
+        Detailed documentation of the metric customization.
+
+   :doc:`How to define a new decoder <./custom_decoder>`
+        Detailed documentation of the decoder customization.
+
+1. Define a new metric, decoder, or selector with :code:`@register` decorator.
+
+   .. code-block:: python
+      :emphasize-lines: 4
+
+      from mbrs.metrics import register, Metric, MetricBLEU
+
+
+      @register("my_bleu")
+      class MetricMyBLEU(MetricBLEU):
+          ...
+
+2. Prepare :code:`__init__.py` to specify classes to be loaded.
+
+   .. code-block:: python
+      :emphasize-lines: 1
+
+      from .new import MetricNew
+
+3. Then, load the modules with :code:`--plugin_dir` option with a path to the directory containing the above :code:`__init__.py`.
+
+   .. code-block:: bash
+      :emphasize-lines: 2,6
+
+      mbrs-decode \
+        --plugin_dir path/to/plugins/ \
+        hypotheses.txt \
+        --num_candidates 1024 \
+        --decoder mbr \
+        --metric my_bleu
+
+   `mbrs-score` also supports plug-in loading.
+
+   .. code-block:: bash
+      :emphasize-lines: 2,5
+
+      mbrs-score \
+        --plugin_dir path/to/plugins/ \
+        hypotheses.txt \
+        -r references.txt \
+        --metric my_bleu

--- a/mbrs/args_test.py
+++ b/mbrs/args_test.py
@@ -1,11 +1,44 @@
+import os
 import pathlib
 
+import pytest
 import yaml
 
 from mbrs.cli.decode import get_argparser
+from mbrs.metrics import get_metric
 
 
 class TestArgumentParser:
+    def test_plugin_load(self, tmp_path: pathlib.Path):
+        config_path = tmp_path / "config.yaml"
+        hyps_path = tmp_path / "hyps.txt"
+        cfg_dict = {
+            "common": {
+                "metric": "my_bleu",
+                "hypotheses": str(hyps_path),
+                "num_candidates": 2,
+            },
+        }
+
+        with open(config_path, mode="w") as f:
+            yaml.dump(cfg_dict, f)
+
+        with open(hyps_path, mode="w") as f:
+            f.writelines(["tests", "a test"])
+
+        cmd_args = ["--config_path", str(config_path)]
+        with pytest.raises(NotImplementedError):
+            parser = get_argparser(cmd_args)
+
+        plugin_dir = os.path.join(
+            os.path.dirname(os.path.abspath(__file__)), "tests", "plugins"
+        )
+        cmd_args += ["--plugin_dir", plugin_dir]
+        parser = get_argparser(cmd_args)
+        args = parser.parse_args(args=cmd_args)
+        assert args.common.metric == "my_bleu"
+        assert get_metric(args.common.metric).__name__ == "MetricMyBLEU"
+
     def test_config_load(self, tmp_path: pathlib.Path):
         config_path = tmp_path / "config.yaml"
         hyps_path = tmp_path / "hyps.txt"

--- a/mbrs/tests/plugins/__init__.py
+++ b/mbrs/tests/plugins/__init__.py
@@ -1,0 +1,1 @@
+from .my_bleu import MetricMyBLEU

--- a/mbrs/tests/plugins/my_bleu.py
+++ b/mbrs/tests/plugins/my_bleu.py
@@ -1,0 +1,6 @@
+from mbrs.metrics import MetricBLEU, register
+
+
+@register("my_bleu")
+class MetricMyBLEU(MetricBLEU):
+    """My customized metric class."""


### PR DESCRIPTION
Plug-in module loader loads user defined modules via `--plugin_dir` option in `mbrs-decode` and `mbrs-score`.
Users can import external codes without cloning this repository, which could be helpful for developing new metrics or decoders.