### PR TITLE
Refactor cacheable metrics and speed up BERTScore

### DIFF
--- a/mbrs/decoders/centroid_mbr_test.py
+++ b/mbrs/decoders/centroid_mbr_test.py
@@ -3,6 +3,7 @@ import torch
 
 from mbrs.decoders.aggregate_mbr import DecoderAggregateMBR
 from mbrs.metrics.comet import MetricCOMET
+from mbrs.modules.kmeans import Kmeans
 from mbrs.selectors.base import Selector
 
 from .centroid_mbr import DecoderCentroidMBR
@@ -42,7 +43,9 @@ class TestDecoderCBMBR:
     @pytest.mark.parametrize("kmeanspp", [True, False])
     def test_decode(self, metric_comet: MetricCOMET, kmeanspp: bool):
         decoder = DecoderCentroidMBR(
-            DecoderCentroidMBR.Config(ncentroids=NCENTROIDS, kmeanspp=kmeanspp),
+            DecoderCentroidMBR.Config(
+                Kmeans.Config(ncentroids=NCENTROIDS, kmeanspp=kmeanspp)
+            ),
             metric_comet,
         )
         for i, (hyps, refs) in enumerate(zip(HYPOTHESES, REFERENCES)):
@@ -76,7 +79,7 @@ class TestDecoderCBMBR:
         self, metric_comet: MetricCOMET, nbest: int, kmeanspp: bool, selector: Selector
     ):
         decoder_cbmbr = DecoderCentroidMBR(
-            DecoderCentroidMBR.Config(ncentroids=1, kmeanspp=kmeanspp),
+            DecoderCentroidMBR.Config(Kmeans.Config(ncentroids=1, kmeanspp=kmeanspp)),
             metric_comet,
             selector=selector,
         )
@@ -102,7 +105,7 @@ class TestDecoderCBMBR:
         self, metric_comet: MetricCOMET, nbest: int, selector: Selector
     ):
         decoder = DecoderCentroidMBR(
-            DecoderCentroidMBR.Config(ncentroids=NCENTROIDS),
+            DecoderCentroidMBR.Config(Kmeans.Config(ncentroids=NCENTROIDS)),
             metric_comet,
             selector=selector,
         )

--- a/mbrs/decoders/pruning_mbr.py
+++ b/mbrs/decoders/pruning_mbr.py
@@ -153,7 +153,7 @@ class DecoderPruningMBR(DecoderMBR):
                 num_winners = len(winners)
                 if num_winners >= nbest:
                     if isinstance(self.metric, MetricCacheable):
-                        hypotheses_ir = hypotheses_ir.index_select(0, winners)
+                        hypotheses_ir = hypotheses_ir[winners]
                     else:
                         hypotheses = [hypotheses[i] for i in winners]
                     pairwise_scores = pairwise_scores[winners]

--- a/mbrs/metrics/__init__.py
+++ b/mbrs/metrics/__init__.py
@@ -7,6 +7,7 @@ from mbrs import registry
 from .base import (
     Metric,
     MetricAggregatable,
+    MetricAggregatableCache,
     MetricBase,
     MetricCacheable,
     MetricReferenceless,
@@ -28,6 +29,7 @@ __all__ = [
     "MetricBase",
     "Metric",
     "MetricAggregatable",
+    "MetricAggregatableCache",
     "MetricCacheable",
     "MetricReferenceless",
     "MetricBERTScore",

--- a/mbrs/metrics/comet.py
+++ b/mbrs/metrics/comet.py
@@ -1,20 +1,23 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Optional, Sequence
 
 import torch
 from comet import download_model, load_from_checkpoint
 from torch import Tensor
 
-from . import MetricAggregatable, MetricCacheable, register
+from mbrs.modules.kmeans import Kmeans
+
+from . import MetricAggregatableCache, register
 
 
 @register("comet")
-class MetricCOMET(MetricCacheable, MetricAggregatable):
+class MetricCOMET(MetricAggregatableCache):
     """COMET metric class."""
 
     @dataclass
-    class Config(MetricCacheable.Config):
+    class Config(MetricAggregatableCache.Config):
         """COMET metric configuration.
 
         - model (str): Model name or path.
@@ -44,6 +47,77 @@ class MetricCOMET(MetricCacheable, MetricAggregatable):
                 self.scorer = self.scorer.bfloat16()
             self.scorer = self.scorer.cuda()
 
+    @dataclass
+    class Cache(MetricAggregatableCache.Cache):
+        """Intermediate representations of sentences.
+
+        - embeddings (Tensor): Sentence embeddings of shape `(N, D)`, where `N`
+            is the number of sentences and `D` is a size of the embedding
+            dimension.
+        """
+
+        embeddings: Tensor
+
+        def __len__(self) -> int:
+            """Return the length of cache."""
+            return len(self.embeddings)
+
+        def __getitem__(
+            self, key: int | Sequence[int] | slice | Tensor
+        ) -> MetricCOMET.Cache:
+            """Get the items."""
+            return type(self)(self.embeddings[key])
+
+        def repeat(self, n: int) -> MetricCOMET.Cache:
+            """Repeat the representations by n times.
+
+            Args:
+                n (int): The number of repetition.
+
+            Returns:
+                Cache: The repeated cache.
+            """
+            return type(self)(self.embeddings.repeat((n, 1)))
+
+        def aggregate(
+            self, reference_lprobs: Optional[Tensor] = None
+        ) -> MetricCOMET.Cache:
+            """Aggregate the cached representations.
+
+            Args:
+                reference_lprobs (Tensor, optional): Log-probabilities for each reference sample.
+                  The shape must be `(len(references),)`. See `https://arxiv.org/abs/2311.05263`.
+
+            Returns:
+                Cache: An aggregated representation.
+            """
+            if reference_lprobs is not None:
+                aggregated_embedding = (
+                    self.embeddings
+                    * reference_lprobs.to(self.embeddings)
+                    .softmax(dim=-1, dtype=torch.float32)
+                    .to(self.embeddings)[:, None]
+                ).sum(dim=0, keepdim=True)
+            else:
+                aggregated_embedding = self.embeddings.mean(dim=0, keepdim=True)
+            return type(self)(aggregated_embedding)
+
+        def cluster(
+            self, kmeans: Kmeans
+        ) -> tuple[MetricAggregatableCache.Cache, Tensor]:
+            """Cluster the cached representations.
+
+            Args:
+                kmeans (Kmeans): k-means class to perform clustering.
+
+            Returns:
+                tuple[Cache, Tensor]:
+                  - Cache: Centroid representations.
+                  - Tensor: N assigned IDs.
+            """
+            centroids, assigns = kmeans.train(self.embeddings)
+            return type(self)(centroids), assigns
+
     @property
     def embed_dim(self) -> int:
         """Return the size of embedding dimension."""
@@ -54,22 +128,20 @@ class MetricCOMET(MetricCacheable, MetricAggregatable):
         """Returns the device of the model."""
         return self.scorer.device
 
-    def encode(self, sentences: list[str]) -> torch.Tensor:
-        """Compute sentence embedding vectors of the given sentences.
+    def encode(self, sentences: list[str]) -> Cache:
+        """Encode the given sentences into their intermediate representations.
 
         Args:
             sentences (list[str]): Input sentences.
 
         Returns:
-            torch.Tensor: Sentence embeddings of shape `(N, D)`, where
-              - N: the number of sentences
-              - D: size of the embedding dimmension
+            MetricCOMET.Cache: Intermediate representations.
         """
         batches = [
             self.scorer.encoder.prepare_sample(sentences[i : i + self.cfg.batch_size])
             for i in range(0, len(sentences), self.cfg.batch_size)
         ]
-        embeds = []
+        embeddings = []
         for batch in batches:
             emb = self.scorer.get_sentence_embedding(**batch.to(self.scorer.device))
             if self.scorer.device.type != "cpu":
@@ -79,24 +151,25 @@ class MetricCOMET(MetricCacheable, MetricAggregatable):
                     emb = emb.bfloat16()
                 else:
                     emb = emb.float()
-            embeds.append(emb)
-        embeds = torch.vstack(embeds)
-        return embeds
+            embeddings.append(emb)
+        return self.Cache(torch.vstack(embeddings))
 
     def out_proj(
-        self, hypotheses_ir: Tensor, references_ir: Tensor, sources_ir: Tensor
+        self, hypotheses_ir: Cache, references_ir: Cache, sources_ir: Cache
     ) -> Tensor:
         """Forward the output projection layer.
 
         Args:
-            hypotheses_ir (Tensor): Intermediate representations of hypotheses.
-            references_ir (Tensor): Intermediate representations of references.
-            sources_ir (Tensor): Intermediate representations of sources.
+            hypotheses_ir (Cache): N intermediate representations of hypotheses.
+            references_ir (Cache): N intermediate representations of references.
+            sources_ir (Cache, optional): N intermediate representations of sources.
 
         Returns:
             Tensor: N scores.
         """
-        return self.scorer.estimate(sources_ir, hypotheses_ir, references_ir)["score"]
+        return self.scorer.estimate(
+            sources_ir.embeddings, hypotheses_ir.embeddings, references_ir.embeddings
+        )["score"]
 
     def corpus_score(
         self, hypotheses: list[str], references: list[str], sources: list[str]

--- a/mbrs/modules/kmeans_test.py
+++ b/mbrs/modules/kmeans_test.py
@@ -48,12 +48,12 @@ def is_equal_shape(
 class TestKmeans:
     @pytest.mark.parametrize("kmeanspp", [False, True])
     def test___init__(self, kmeanspp: bool):
-        kmeans = Kmeans(kmeanspp)
-        assert kmeans.kmeanspp == kmeanspp
+        kmeans = Kmeans(Kmeans.Config(kmeanspp=kmeanspp))
+        assert kmeans.cfg.kmeanspp == kmeanspp
 
     def test_init_kmeanspp(self):
         x = torch.rand(N, D)
-        kmeans = Kmeans(kmeanspp=True)
+        kmeans = Kmeans(Kmeans.Config(kmeanspp=True, ncentroids=C))
         rng = torch.Generator(x.device)
         rng = rng.manual_seed(0)
         centroids = kmeans.init_kmeanspp(x, rng, C)
@@ -62,7 +62,7 @@ class TestKmeans:
     def test_assign(self):
         x = torch.rand(N, D)
         centroids = torch.rand(C, D)
-        kmeans = Kmeans()
+        kmeans = Kmeans(Kmeans.Config(ncentroids=C))
         assigns = kmeans.assign(x, centroids)
         expected = ((x[:, None] - centroids[None, :]) ** 2).sum(dim=-1).argmin(dim=1)
         assert torch.equal(assigns, expected)
@@ -70,8 +70,8 @@ class TestKmeans:
     @pytest.mark.parametrize("kmeanspp", [False, True])
     def test_train(self, kmeanspp: bool):
         torch.manual_seed(0)
-        kmeans = Kmeans(kmeanspp)
+        kmeans = Kmeans(Kmeans.Config(kmeanspp=kmeanspp, ncentroids=C))
         x = torch.rand(N, D)
-        centroids, assigns = kmeans.train(x, C)
+        centroids, assigns = kmeans.train(x)
         assert is_equal_shape(centroids, [C, D])
         assert is_equal_shape(assigns, [N])


### PR DESCRIPTION
- Refactor cacheable metric classes and define the cache dataclass
- Reimplement BERTScore and speed up the pairwise score calculation