### PR TITLE
Fix a bug of BERTScore encoding

### DIFF
--- a/mbrs/metrics/bertscore.py
+++ b/mbrs/metrics/bertscore.py
@@ -260,7 +260,7 @@ class MetricBERTScore(MetricCacheable):
             batch = self._collate(sequences[i : i + self.cfg.batch_size])
             attention_mask = batch.attention_mask.bool()
             embs = self.model(**batch.to(self.device))[0].cpu()
-            for j in range(i, i + len(embs)):
+            for j in range(len(embs)):
                 embeddings.append(embs[j, attention_mask[j]])
         idf_weights = [
             torch.Tensor([self.idf_dict.get(token, 1.0) for token in seq])

--- a/mbrs/metrics/bertscore_test.py
+++ b/mbrs/metrics/bertscore_test.py
@@ -44,7 +44,7 @@ RECALL_SCORES = torch.Tensor(
 class TestMetricBERTScore:
     @pytest.fixture(scope="class")
     def metric_bertscore(self):
-        return MetricBERTScore(MetricBERTScore.Config(lang="en"))
+        return MetricBERTScore(MetricBERTScore.Config(lang="en", batch_size=8))
 
     def test_score(self, metric_bertscore: MetricBERTScore):
         for i, hyp in enumerate(HYPOTHESES):
@@ -108,6 +108,13 @@ class TestMetricBERTScore:
                 [0.9999998807907104, 0.9457088112831116, 0.949202835559845]
             ).mean(),
         )
+
+    def test_encode_batch(self, metric_bertscore: MetricBERTScore):
+        N = metric_bertscore.cfg.batch_size + 2
+        hyps = ["this is a test"] * N
+        cache = metric_bertscore.encode(hyps)
+        assert len(cache.embeddings) == N
+        assert len(cache.idf_weights) == N
 
 
 @pytest.mark.metrics_bertscore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mbrs"
-version = "0.1.5"
+version = "0.1.6"
 description = "A library for minimum Bayes risk (MBR) decoding."
 readme = "README.md"
 authors = [


### PR DESCRIPTION
Fixed sentence encoding of `MetricBERTScore`.
This pullreq fixed a bug of wrong indices for extracting feature embeddings when the total number of input sentences exceed the mini-batch size.